### PR TITLE
Update _ruby.md

### DIFF
--- a/source/includes/_ruby.md
+++ b/source/includes/_ruby.md
@@ -111,7 +111,7 @@ bundle list scout_apm
       </td>
       <td>
         <p>
-          Did you restart the app?
+          Did you restart the app and let it run for a while?
         </p>
       </td>
     </tr>


### PR DESCRIPTION
I went back through older support messages to check if adding in directions to let the app run for a while was needed. While the amount of time to let an app run after restarting it varied (Anywhere from 5-10 minutes), it is necessary to mention that the app needs to run for a bit.