### PR TITLE
Remove one header level from "our monitoring stack"

### DIFF
--- a/source/includes/_reference.md
+++ b/source/includes/_reference.md
@@ -159,7 +159,7 @@ In many cases, Scout is able to replace New Relic as-is. However, there are case
 
 * __Browser Monitoring (Real User Monitoring)__ - there are a number of dedicated tools for both Real User Monitoring (RUM) and synthetic monitoring. We've [reviewed Raygun Pulse](https://scoutapm.com/blog/real-user-monitoring-with-raygun), an attractive RUM product. You can also continue to use New Relic for browser monitoring and use Scout for application monitoring.
 
-### Our Monitoring Stack
+## Our Monitoring Stack
 
 Curious about what a company that lives-and-breathes monitoring (us!) uses to monitor our apps? [We shared our complete monitoring stack on our blog](https://scoutapm.com/blog/rails-monitoring-stack-2016).
 


### PR DESCRIPTION
Before this change, "Our Monitoring Stack" appeared as a sub-header of "Replacing New Relic", which could be taken to imply you did or do use New Relic. I think it's more correct as its own h2, with "Talk to us about your monitoring stack" below it.
