### PR TITLE
Hide PECL install step for PHP temporarily

### DIFF
--- a/source/includes/_php.md
+++ b/source/includes/_php.md
@@ -59,7 +59,7 @@ not need to be installed directly.
 </p>
       </td>
     </tr>
-    <tr>
+<!--    <tr>
       <td>
         <span class="step">2</span>
       </td>
@@ -74,10 +74,10 @@ Several instruments require the native extension to be included, including timin
 For more information, or to compile manually, the <a href="https://github.com/scoutapp/scout-apm-php-ext">README</a> has additional instructions.
 </p>
       </td>
-    </tr>
+    </tr> -->
     <tr>
       <td>
-        <span class="step">3</span>
+        <span class="step">2</span>
       </td>
       <td style="padding-top: 15px">
         <p>Configure Scout in your <code>.env</code> file:</p>
@@ -94,7 +94,7 @@ If you've installed Scout via the Heroku Addon, the provisioning process automat
       </td>
     </tr>
     <tr>
-      <td><span class="step">4</span></td>
+      <td><span class="step">3</span></td>
       <td style="padding-top: 15px">
         <p>Deploy.</p>
         <p>It takes approximatively five minutes for your data to first appear within the Scout UI.</p>


### PR DESCRIPTION
Having the pecl extension enabled in PHP exposed a bug. Temporarily hide the pecl documentation.