### PR TITLE
Remove special Django list

### DIFF
--- a/source/includes/_python.md
+++ b/source/includes/_python.md
@@ -23,10 +23,6 @@ The libraries below require a small number of configuration updates. Click on th
 * [Celery](#celery)
 * [Dash](#dash)
 * [Django](#django)
-    * Middleware
-    * Templates (compiling & rendering)
-    * Template blocks
-    * SQL queries
 * [Dramatiq](#dramatiq)
 * [Falcon](#falcon)
 * [Flask](#flask)


### PR DESCRIPTION
We don't have lists for the other libraries, seems a bit unfair to highlight everything in Django.
